### PR TITLE
PV-148 Fix/openshift incompatibility issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ ARG IMAGE_VARIANT=slim
 FROM ${BASE_IMAGE}:${NODE_VERSION}-${IMAGE_VARIANT} AS base_stage
 # ==============================
 
-RUN groupadd --system --gid 2000 appgroup && \
-    useradd  --system --gid      appgroup --create-home --uid 3000 appuser
-
 WORKDIR /app
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,6 @@ RUN yarn install --frozen-lockfile --production=false && \
 
 COPY . /app/
 
-USER appuser:appgroup
-
 # ==============================
 FROM base_stage AS production_stage
 # ==============================
@@ -45,5 +43,3 @@ RUN yarn install --frozen-lockfile --production=true && \
     yarn cache clean
 
 COPY . /app/
-
-USER appuser:appgroup

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ARG IMAGE_VARIANT=slim
 FROM ${BASE_IMAGE}:${NODE_VERSION}-${IMAGE_VARIANT} AS base_stage
 # ==============================
 
-RUN groupadd --system --gid 0 appgroup && \
-    useradd  --system --gid   appgroup --create-home --uid 3000 appuser
+RUN groupadd --system --gid 2000 appgroup && \
+    useradd  --system --gid      appgroup --create-home --uid 3000 appuser
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ARG IMAGE_VARIANT=slim
 FROM ${BASE_IMAGE}:${NODE_VERSION}-${IMAGE_VARIANT} AS base_stage
 # ==============================
 
-RUN groupadd --system --gid 2000 appgroup && \
-    useradd  --system --gid      appgroup --create-home --uid 3000 appuser
+RUN groupadd --system --gid 0 appgroup && \
+    useradd  --system --gid   appgroup --create-home --uid 3000 appuser
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN yarn install --frozen-lockfile --production=false && \
 COPY . /app/
 
 USER appuser:appgroup
-CMD ["yarn", "develop"]
 
 # ==============================
 FROM base_stage AS production_stage
@@ -48,4 +47,3 @@ RUN yarn install --frozen-lockfile --production=true && \
 COPY . /app/
 
 USER appuser:appgroup
-CMD ["yarn", "start"]

--- a/azure-pipelines-develop.yml
+++ b/azure-pipelines-develop.yml
@@ -1,14 +1,14 @@
 # File: parking-permits-gateway/azure-pipelines-develop.yml
 
-# Continuous integration (CI) triggers cause a pipeline to run whenever you push 
+# Continuous integration (CI) triggers cause a pipeline to run whenever you push
 # an update to the specified branches or you push specified tags.
 trigger:
   branches:
     include:
-    - develop
+      - develop
   paths:
     exclude:
-    - README.md
+      - README.md
 
 # By default, use self-hosted agents
 pool: Default
@@ -18,11 +18,11 @@ pr: none
 
 resources:
   repositories:
-  # Azure DevOps repository
-  - repository: pysakoinnin-verkkokauppa-pipelines
-    type: git
-    # project/repository
-    name: pysakoinnin-verkkokauppa/pysakoinnin-verkkokauppa-pipelines
+    # Azure DevOps repository
+    - repository: pysakoinnin-verkkokauppa-pipelines
+      type: git
+      # project/repository
+      name: pysakoinnin-verkkokauppa/pysakoinnin-verkkokauppa-pipelines
 
 extends:
   template: azure-pipelines-pysakoinninverkkokauppa-gateway-test.yml@pysakoinnin-verkkokauppa-pipelines

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,14 +1,14 @@
 # File: parking-permits-gateway/azure-pipelines-release.yml
 
-# Continuous integration (CI) triggers cause a pipeline to run whenever you push 
+# Continuous integration (CI) triggers cause a pipeline to run whenever you push
 # an update to the specified branches or you push specified tags.
 trigger:
   branches:
     include:
-    - main
+      - main
   paths:
     exclude:
-    - README.md
+      - README.md
 
 # By default, use self-hosted agents
 pool: Default
@@ -18,11 +18,11 @@ pr: none
 
 resources:
   repositories:
-  # Azure DevOps repository
-  - repository: pysakoinnin-verkkokauppa-pipelines
-    type: git
-    # project/repository
-    name: pysakoinnin-verkkokauppa/pysakoinnin-verkkokauppa-pipelines
+    # Azure DevOps repository
+    - repository: pysakoinnin-verkkokauppa-pipelines
+      type: git
+      # project/repository
+      name: pysakoinnin-verkkokauppa/pysakoinnin-verkkokauppa-pipelines
 
 extends:
   template: azure-pipelines-pysakoinninverkkokauppa-gateway-stgn-prod.yml@pysakoinnin-verkkokauppa-pipelines

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
     environment:
+      - DEV_SERVER=true
       - DOCKER_BIND_MOUNT_IN_USE=true
       - INSTALL_PRECOMMIT=true
       - PARKING_PERMITS_GRAPHQL_API=http://graphql-api:8000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,3 +15,8 @@ if [[ "$INSTALL_PRECOMMIT" = "true" ]]; then
     yarn run husky install
 fi
 
+if [[ "$DEV_SERVER" = "true" ]]; then
+    yarn run develop
+else
+    yarn run start
+fi


### PR DESCRIPTION
Some comments 😊:

* Updating appgroup GID to 0 doesn't work as the build crashes with an error along the lines of "number 0 is already in use".
* a78b09ce479c11aeddca7eb5e06827aeb3d8e6da and 187c0d45bc839653ac57b6dbfd4dfc97d61fa2ab and b1e25684b6315f927217c471ee5144671a81ef47 commits are reverting the changes. The reason for that is that they were breaking the `docker-compose up` and you could no longer run the server locally with `docker-compose up`.
* `USER` directives and non root user and group creation were removed. That's because I got confirmation from IBM expert that containers are FORCED to run as a random user in Openshift, no matter what, and therefore we don't need to set `USER` explicitly. Setting `USER` will crash the pods in Openshift.